### PR TITLE
Custom cache

### DIFF
--- a/cache.js
+++ b/cache.js
@@ -1,0 +1,118 @@
+'use strict'
+
+module.exports = [
+  {
+    urlPattern: /^https:\/\/fonts\.(?:googleapis|gstatic)\.com\/.*/i,
+    handler: 'CacheFirst',
+    options: {
+      cacheName: 'google-fonts',
+      expiration: {
+        maxEntries: 4,
+        maxAgeSeconds: 365 * 24 * 60 * 60 // 365 days
+      }
+    }
+  },
+  {
+    urlPattern: /^https:\/\/use\.fontawesome\.com\/releases\/.*/i,
+    handler: 'CacheFirst',
+    options: {
+      cacheName: 'font-awesome',
+      expiration: {
+        maxEntries: 1,
+        maxAgeSeconds: 365 * 24 * 60 * 60 // 365 days
+      }
+    }
+  },
+  {
+    urlPattern: /\.(?:eot|otf|ttc|ttf|woff|woff2|font.css)$/i,
+    handler: 'StaleWhileRevalidate',
+    options: {
+      cacheName: 'static-font-assets',
+      expiration: {
+        maxEntries: 4,
+        maxAgeSeconds: 7 * 24 * 60 * 60 // 7 days
+      }
+    }
+  },
+  {
+    urlPattern: /\.(?:jpg|jpeg|gif|png|svg|ico|webp)$/i,
+    handler: 'StaleWhileRevalidate',
+    options: {
+      cacheName: 'static-image-assets',
+      expiration: {
+        maxEntries: 64,
+        maxAgeSeconds: 24 * 60 * 60 // 24 hours
+      }
+    }
+  },
+  {
+    urlPattern: /\.(?:js)$/i,
+    handler: 'StaleWhileRevalidate',
+    options: {
+      cacheName: 'static-js-assets',
+      expiration: {
+        maxEntries: 16,
+        maxAgeSeconds: 24 * 60 * 60 // 24 hours
+      }
+    }
+  },
+  {
+    urlPattern: /\.(?:css|less)$/i,
+    handler: 'StaleWhileRevalidate',
+    options: {
+      cacheName: 'static-style-assets',
+      expiration: {
+        maxEntries: 16,
+        maxAgeSeconds: 24 * 60 * 60 // 24 hours
+      }
+    }
+  },
+  {
+    urlPattern: /\.(?:json|xml|csv)$/i,
+    handler: 'StaleWhileRevalidate',
+    options: {
+      cacheName: 'static-data-assets',
+      expiration: {
+        maxEntries: 16,
+        maxAgeSeconds: 24 * 60 * 60 // 24 hours
+      }
+    }
+  },
+  {
+    urlPattern: /\/api\/.*$/i,
+    handler: 'NetworkFirst',
+    method: 'GET',
+    options: {
+      cacheName: 'apis',
+      expiration: {
+        maxEntries: 16,
+        maxAgeSeconds: 24 * 60 * 60 // 24 hours
+      },
+      networkTimeoutSeconds: 10 // fall back to cache if api does not response within 10 seconds
+    }
+  },
+  {
+    urlPattern: /\/api\/.*$/i,
+    handler: 'NetworkFirst',
+    method: 'POST',
+    options: {
+      cacheName: 'apis',
+      expiration: {
+        maxEntries: 16,
+        maxAgeSeconds: 24 * 60 * 60 // 24 hours
+      },
+      networkTimeoutSeconds: 10 // fall back to cache if api does not response within 10 seconds
+    }
+  },
+  {
+    urlPattern: /.*/i,
+    handler: 'NetworkFirst',
+    options: {
+      cacheName: 'others',
+      expiration: {
+        maxEntries: 16,
+        maxAgeSeconds: 24 * 60 * 60 // 24 hours
+      }
+    }
+  }
+]

--- a/next.config.js
+++ b/next.config.js
@@ -1,10 +1,12 @@
 const withPWA = require('next-pwa');
+const runtimeCaching = require('./cache')
 
 module.exports = withPWA({
   pwa: {
     dest: 'public',
     precacheHomePage: false,
     additionalManifestEntries: [],
+    runtimeCaching
   },
   pageExtensions: ['page.js'],
 });


### PR DESCRIPTION
Note the last runtime caching is changed to `NetworkFirst`
``` javascript
  {
    urlPattern: /.*/i,
    handler: 'NetworkFirst',
    options: {
      cacheName: 'others',
      expiration: {
        maxEntries: 16,
        maxAgeSeconds: 24 * 60 * 60 // 24 hours
      }
    }
```